### PR TITLE
Improve repo-specific Mean Time to First Commit metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,12 @@
     > metrics@0.0.1 start
     > node index.js
 
-    Mean Time to First Commit based on Roster: 104.24 days
-    Mean Time to First Commit based on GitHub Onboarding Issues: 32.30 days
+    Mean Time to First Commit based on Roster (days): 104.24
+    Mean Time to First Commit based on Roster (days) (vets-website only): 110.32
+    Mean Time to First Commit based on Roster (days) (vets-api only): 98.16
+    Mean Time to First Commit based on GitHub Onboarding Issues (days): 32.30
+    Mean Time to First Commit based on GitHub Onboarding Issues (days) (vets-website only): 35.45
+    Mean Time to First Commit based on GitHub Onboarding Issues (days) (vets-api only): 29.15
 
 ## Mean Time to First Commit
 
@@ -29,3 +33,10 @@ Each run of the calculator produces two calculations of the MTTFC. The reason fo
 1.  [VA.gov GitHub Onboarding Template Issues](https://github.com/department-of-veterans-affairs/va.gov-team/issues?q=is%3Aissue+label%3Aplatform-orientation+is%3Aall)
 
 For each onboarder, the calculator finds their first commit after their onboarding began to either [`vets-api`](https://github.com/department-of-veterans-affairs/vets-api) or [`vets-website`](https://github.com/department-of-veterans-affairs/vets-website). The time to first commit is the number of days between the start of their onboarding and their first commit. These days-to-first-commit measurements are then averaged to produce a "mean time to first commit".
+
+The calculator now also computes separate metrics for each repository:
+1. **Overall MTTFC**: The original metric, which considers the first commit to either repository
+2. **MTTFC for vets-website only**: Mean time to first commit considering only commits to the vets-website repository
+3. **MTTFC for vets-api only**: Mean time to first commit considering only commits to the vets-api repository
+
+This breakdown helps teams understand if there are significant differences in onboarding time between frontend (vets-website) and backend (vets-api) development.

--- a/index.js
+++ b/index.js
@@ -63,9 +63,10 @@ const calculateMeanTimeToFirstCommit = async (
     commitRepository,
   );
 
-  const meanTimeToFirstCommit =
-    await meanTimeToFirstCommitCalculator.calculate();
-  console.log(`${label}: ${meanTimeToFirstCommit.toFixed(2)}`);
+  const results = await meanTimeToFirstCommitCalculator.calculate();
+  console.log(`${label}: ${results.overall.toFixed(2)}`);
+  console.log(`${label} (vets-website only): ${results['vets-website'].toFixed(2)}`);
+  console.log(`${label} (vets-api only): ${results['vets-api'].toFixed(2)}`);
 };
 
 /* node:coverage disable */

--- a/src/MeanTimeToFirstCommitCalculator.js
+++ b/src/MeanTimeToFirstCommitCalculator.js
@@ -6,27 +6,78 @@ export default class MeanTimeToFirstCommitCalculator {
 
   async calculate() {
     const onboarders = await this.onboarderRepository.findAll();
-    const possibleDaysToFirstCommit = await Promise.all(
+    const results = {
+      overall: [],
+      'vets-website': [],
+      'vets-api': []
+    };
+
+    // Track total onboarders who made at least one commit
+    let totalOnboardersWithCommits = 0;
+    // Track sum of all days to first commit (for either repo)
+    let totalDaysToFirstCommit = 0;
+
+    await Promise.all(
       onboarders.map(async (onboarder) => {
-        const possibleCommits = await Promise.all(
-          ["vets-website", "vets-api"].map((repo) =>
-            this.commitRepository.findFirstBy(repo, onboarder),
-          ),
-        );
-        const commits = possibleCommits.filter((commit) => commit);
-        return onboarder.daysToFirstCommit(commits);
-      }),
+        // First get all commits for the onboarder across all repositories
+        const repoCommits = {};
+        for (const repo of ["vets-website", "vets-api"]) {
+          const commit = await this.commitRepository.findFirstBy(repo, onboarder);
+          if (commit) {
+            repoCommits[repo] = commit;
+          }
+        }
+
+        // If they made a commit to either repo, include them in the overall calculation
+        const commits = Object.values(repoCommits);
+        if (commits.length > 0) {
+          totalOnboardersWithCommits++;
+
+          // Calculate the earliest commit date across all repos for this onboarder
+          const daysToFirstCommit = onboarder.daysToFirstCommit(commits);
+          if (daysToFirstCommit !== null) {
+            totalDaysToFirstCommit += daysToFirstCommit;
+
+            // Now determine which repo was their actual first commit
+            // Find the repo with the earliest commit date
+            let earliestRepo = null;
+            let earliestDate = new Date(8640000000000000); // Max date
+
+            for (const [repo, commit] of Object.entries(repoCommits)) {
+              if (commit.date < earliestDate) {
+                earliestDate = commit.date;
+                earliestRepo = repo;
+              }
+            }
+
+            // Only include this commit in the repo-specific metric if it was their first overall
+            if (earliestRepo) {
+              const daysDiff = onboarder.daysToFirstCommit([repoCommits[earliestRepo]]);
+              if (daysDiff !== null) {
+                results[earliestRepo].push(daysDiff);
+              }
+            }
+          }
+        }
+      })
     );
 
-    const daysToFirstCommit = possibleDaysToFirstCommit.filter((days) => days);
-    if (!daysToFirstCommit.length) {
+    // Calculate overall mean
+    results.overall = totalOnboardersWithCommits > 0 ?
+      totalDaysToFirstCommit / totalOnboardersWithCommits :
+      0;
+
+    return {
+      overall: results.overall,
+      'vets-website': this.calculateMean(results['vets-website']),
+      'vets-api': this.calculateMean(results['vets-api'])
+    };
+  }
+
+  calculateMean(daysArray) {
+    if (!daysArray.length) {
       return 0;
     }
-
-    const meanTimeToFirstCommit =
-      daysToFirstCommit.reduce((total, days) => total + days) /
-      daysToFirstCommit.length;
-
-    return meanTimeToFirstCommit;
+    return daysArray.reduce((total, days) => total + days) / daysArray.length;
   }
 }

--- a/src/e2e.test.js
+++ b/src/e2e.test.js
@@ -48,7 +48,7 @@ describe("happy path", () => {
       );
     });
 
-    it("logs the mean time to first commit", async () => {
+    it("logs the mean time to first commit overall and by repo", async () => {
       mock.method(console, "log");
       const roster = [];
 
@@ -58,6 +58,22 @@ describe("happy path", () => {
         console.log.mock.calls.some((call) =>
           call.arguments.includes(
             "Mean Time to First Commit based on GitHub Onboarding Issues (days): 3.00",
+          ),
+        ),
+      );
+
+      assert.ok(
+        console.log.mock.calls.some((call) =>
+          call.arguments.includes(
+            "Mean Time to First Commit based on GitHub Onboarding Issues (days) (vets-website only): 3.00",
+          ),
+        ),
+      );
+
+      assert.ok(
+        console.log.mock.calls.some((call) =>
+          call.arguments.includes(
+            "Mean Time to First Commit based on GitHub Onboarding Issues (days) (vets-api only): 0.00",
           ),
         ),
       );
@@ -92,7 +108,7 @@ describe("happy path", () => {
       );
     });
 
-    it("logs the mean time to first commit", async () => {
+    it("logs the mean time to first commit overall and by repo", async () => {
       mock.method(console, "log");
 
       await main(roster);
@@ -101,6 +117,22 @@ describe("happy path", () => {
         console.log.mock.calls.some((call) =>
           call.arguments.includes(
             "Mean Time to First Commit based on Roster (days): 13.00",
+          ),
+        ),
+      );
+
+      assert.ok(
+        console.log.mock.calls.some((call) =>
+          call.arguments.includes(
+            "Mean Time to First Commit based on Roster (days) (vets-website only): 0.00",
+          ),
+        ),
+      );
+
+      assert.ok(
+        console.log.mock.calls.some((call) =>
+          call.arguments.includes(
+            "Mean Time to First Commit based on Roster (days) (vets-api only): 13.00",
           ),
         ),
       );


### PR DESCRIPTION
Track separate metrics for vets-api and vets-website based on which was the developer's first commit destination. This provides more accurate insights into which repo onboarders typically contribute to first and how long it takes them.